### PR TITLE
[YS] .gitignore에 .vs/ 디렉토리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Debug/
 /Release/
+.vs/


### PR DESCRIPTION
.gitignore 파일에 .vs/ 디렉토리를 제외 대상으로 추가했습니다.
이는 Visual Studio에서 생성되는 사용자별 설정 파일을 Git의 추적에서
제외하기 위한 변경입니다. 기존의 /Debug/ 및 /Release/ 항목은 그대로
유지되었습니다.